### PR TITLE
Add travis build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: java
+
+jdk:
+  - oraclejdk8
+  - openjdk8
+  - openjdk7
+
+os:
+  - linux
+
+before_install:
+  - sudo wget "https://bouncycastle.org/download/bcprov-ext-jdk15on-158.jar" -O "${JAVA_HOME}/jre/lib/ext/bcprov-ext-jdk15on-158.jar"
+  - sudo perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security
+  - echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security
+
+cache:
+  directories:
+- $HOME/.gradle
+


### PR DESCRIPTION
It patches openjdk7 so it can download
the gradle distribution zip from the
interwebs, since that one uses new TLS
algorithms not present in openjdk7.